### PR TITLE
Miktex: Fix redirect to FTP download URL

### DIFF
--- a/miktex/tools/chocolateyInstall.ps1
+++ b/miktex/tools/chocolateyInstall.ps1
@@ -11,11 +11,11 @@ Function Get-RedirectedUrl {
    Param ([Parameter(Mandatory=$true)][String]$url)
 
    $request = [System.Net.WebRequest]::Create($url)
-   $request.AllowAutoRedirect=$true
+   $request.AllowAutoRedirect=$false
 
    try {
       $response=$request.GetResponse()
-      $response.ResponseUri.AbsoluteUri
+      $response.Headers["Location"]
       $response.Close()
    } catch {
       throw $_.Exception 


### PR DESCRIPTION
CTAN mirror URL may redirect to FTP server for some mirrors.
Fix redirect request handler to support FTP URI location.
