### PR TITLE
[geforce-game-ready-driver-win7] Add parameter to skip GFE install

### DIFF
--- a/geforce-game-ready-driver-win7/tools/chocolateyInstall.ps1
+++ b/geforce-game-ready-driver-win7/tools/chocolateyInstall.ps1
@@ -9,11 +9,24 @@ $setupFile = Join-Path "$unpackDir" "setup.exe"
 $url = "http://us.download.nvidia.com/Windows/{{PackageVersion}}/{{PackageVersion}}-desktop-win8-win7-32bit-international-whql.exe"
 $url64 = "http://us.download.nvidia.com/Windows/{{PackageVersion}}/{{PackageVersion}}-desktop-win8-win7-64bit-international-whql.exe"
 
+$params = "$env:chocolateyPackageParameters"
+$params = (ConvertFrom-StringData $params.Replace(";", "`n")) 
+
+function nogfe($params) {
+    return ($params.nogfe -eq $true) 
+}
+
 
 Get-ChocolateyWebFile $packageName $unpackFile $url $url64 -Checksum {{checksum}} -ChecksumType 'sha256' -Checksum64 {{checksumx64}} -ChecksumType64 'sha256'
 Get-ChocolateyUnzip $unpackFile $unpackDir
 Remove-Item $unpackDir\Update.Core -Recurse -Force
 Remove-Item $unpackDir\Display.Update -Recurse -Force
 Remove-Item $unpackDir\ShadowPlay -Recurse -Force
+if (nogfe($params))
+{
+    Remove-Item $unpackDir\GFExperience -Recurse -Force
+    Remove-Item $unpackDir\GFExperience.NvStreamSrv -Recurse -Force
+    Remove-Item $unpackDir\GfExperienceService -Recurse -Force
+}
 Install-ChocolateyInstallPackage $packageName $fileType $silentArgs $setupFile
 Remove-Item $unpackDir -Recurse -Force


### PR DESCRIPTION
I stole some code from the jdk8 package to allow skipping the Geforce Experience install. I was unable to test this due to Windows insisting on reinstalling the Nvidia driver every time I rebooted, despite me having disabled that setting. I'll have to set up a test machine with my old 450 and test it there when I get some time. That said, if just deleting stuff from the installer zip works without issues, I don't see why this patch wouldn't work.

If by any chance you feel like testing this yourself, be my guest. If not, I'll get around to it within a day or two.

Let me know if you have any comments.