### PR TITLE
Silent install without AutoHotKey

### DIFF
--- a/googleearthpro/tools/chocolateyInstall.ps1
+++ b/googleearthpro/tools/chocolateyInstall.ps1
@@ -6,11 +6,10 @@ $ahkFile = "$toolsDir\button.ahk"
 $packageArgs = @{
   packageName   = $packageName
   fileType      = 'EXE'
-  silentArgs    = ''
+  silentArgs    = 'OMAHA=1'
   url           = $url
   checksum 		= '{{checksum}}'
   ChecksumType 	= 'sha256'
 }
 
-Start-Process 'AutoHotkey' $ahkFile
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Who knows why it is so bizarre, but there is a silent switch for the Google Earth Pro installer.  The current package opens GEP on completion.  This switch prevents that.  I'm not sure how to eliminate the .ahk file in this pull request.