### PR TITLE
Removed AHK dependency

### DIFF
--- a/googleearthpro/googleearthpro.nuspec
+++ b/googleearthpro/googleearthpro.nuspec
@@ -11,16 +11,18 @@
     <iconUrl>https://cdn.rawgit.com/aronovgj/chocolatey/4b19b72cdcde1babe693bafea0a0e8fa06b9a66f/icons/googleearthpro.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Google Earth lets you fly anywhere on Earth to view satellite imagery, maps, terrain, 3D buildings, from galaxies in outer space to the canyons of the ocean.
-	
-Key: 	
+  
+Key:  
 `GEPFREE`
-	</description>
+    </description>
     <summary>Google Earth lets you fly anywhere on Earth to view satellite imagery, maps, terrain, 3D buildings, from galaxies in outer space to the canyons of the ocean.</summary>
     <copyright>©2015 Google</copyright>
     <dependencies>
-        <dependency id="autohotkey.portable" />
     </dependencies>
-	<packageSourceUrl>https://github.com/aronovgj/choco-auto</packageSourceUrl>
+    <packageSourceUrl>https://github.com/aronovgj/choco-auto</packageSourceUrl>
     <tags>google earth navigation geographic mapping admin</tags>
   </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
 </package>

--- a/googleearthpro/tools/button.ahk
+++ b/googleearthpro/tools/button.ahk
@@ -1,5 +1,0 @@
-WinWait, Google Earth Pro, , 300
-ControlClick, Button6, Google Earth Pro
-
-WinWait, Google Earth, , 300
-ControlClick, Button1, Google Earth

--- a/googleearthpro/tools/chocolateyInstall.ps1
+++ b/googleearthpro/tools/chocolateyInstall.ps1
@@ -6,11 +6,10 @@ $ahkFile = "$toolsDir\button.ahk"
 $packageArgs = @{
   packageName   = $packageName
   fileType      = 'EXE'
-  silentArgs    = ''
+  silentArgs    = 'OMAHA=1'
   url           = $url
   checksum 		= '{{checksum}}'
   ChecksumType 	= 'sha256'
 }
 
-Start-Process 'AutoHotkey' $ahkFile
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
AHK is not needed by using a (strange) switch.  Now this package is
totally silent.